### PR TITLE
Add WebSub support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ security, multiuser support, and overall design.
 * multi user capable
 * public compilations to share tagged content with others
 * search stored feed entries
+* Support for [WebSub](https://en.wikipedia.org/wiki/WebSub) push notifications
 
 ### YouTube integration
 

--- a/fof-db.php
+++ b/fof-db.php
@@ -263,20 +263,22 @@ function fof_db_feed_update_metadata($feed_id, $title, $link, $feed_url, $descri
 
 /** Update a feed's WebSub subscription.
  */
-function fof_db_feed_update_websub($feed_id, $hub, $lease, $secret) {
+function fof_db_feed_update_websub($feed_id, $hub, $secret, $lease = null) {
 	global $FOF_FEED_TABLE;
 	global $fof_connection;
 
 	fof_trace();
 
-	$query = "UPDATE $FOF_FEED_TABLE SET feed_websub_hub = :hub, feed_websub_lease = :lease, feed_websub_secret = :secret WHERE feed_id = :feed_id";
+	$query = "UPDATE $FOF_FEED_TABLE SET feed_websub_hub = :hub";
+	if ($lease) {
+		$query .= ", feed_websub_lease = :lease";
+	}
+	$query .= ", feed_websub_secret = :secret WHERE feed_id = :feed_id";
 	$statement = $fof_connection->prepare($query);
 	$statement->bindValue(':feed_id', $feed_id);
 	$statement->bindValue(':hub', $hub);
-	if (!empty($websub_lease)) {
+	if ($lease) {
 		$statement->bindValue(':lease', $lease);
-	} else {
-		$statement->bindValue(':lease', null, PDO::PARAM_NULL);
 	}
 	$statement->bindValue(':secret', $secret);
 

--- a/fof-db.php
+++ b/fof-db.php
@@ -236,16 +236,17 @@ function fof_db_feed_update_attempt_status($feed_id, $status) {
 
 /** Store the various data which describes a feed.
  */
-function fof_db_feed_update_metadata($feed_id, $title, $link, $description, $image, $image_cache_date) {
+function fof_db_feed_update_metadata($feed_id, $title, $link, $feed_url, $description, $image, $image_cache_date) {
 	global $FOF_FEED_TABLE;
 	global $fof_connection;
 
 	fof_trace();
 
-	$query = "UPDATE $FOF_FEED_TABLE SET feed_title = :title, feed_link = :link, feed_description = :description, feed_image = :image, feed_image_cache_date = :image_cache_date WHERE feed_id = :feed_id";
+	$query = "UPDATE $FOF_FEED_TABLE SET feed_title = :title, feed_link = :link, feed_url = :feed_url, feed_description = :description, feed_image = :image, feed_image_cache_date = :image_cache_date WHERE feed_id = :feed_id";
 	$statement = $fof_connection->prepare($query);
 	$statement->bindValue(':title', empty($title) ? "[no title]" : $title);
 	$statement->bindValue(':link', empty($link) ? "[no link]" : $link);
+	$statement->bindValue(':feed_url', $feed_url);
 	$statement->bindValue(':description', empty($description) ? "[no description]" : $description);
 	if (!empty($image)) {
 		$statement->bindValue(':image', $image);
@@ -254,6 +255,30 @@ function fof_db_feed_update_metadata($feed_id, $title, $link, $description, $ima
 	}
 	$statement->bindValue(':image_cache_date', empty($image_cache_date) ? time() : $image_cache_date);
 	$statement->bindValue(':feed_id', $feed_id);
+	$result = $statement->execute();
+	$statement->closeCursor();
+
+	return $result;
+}
+
+/** Update a feed's WebSub subscription.
+ */
+function fof_db_feed_update_websub($feed_id, $websub_hub, $websub_lease) {
+	global $FOF_FEED_TABLE;
+	global $fof_connection;
+
+	fof_trace();
+
+	$query = "UPDATE $FOF_FEED_TABLE SET feed_websub_hub = :websub_hub, feed_websub_lease = :websub_lease WHERE feed_id = :feed_id";
+	$statement = $fof_connetion->prepare($query);
+	$statement->bindValue(':feed_id', $feed_id);
+	$statement->bindValue(':websub_hub', $websub_hub);
+	if (!empty($websub_lease)) {
+		$statement->bindValue(':websub_lease', $websub_lease);
+	} else {
+		$statement->bindValue(':websub_lease', null, PDO::PARAM_NULL);
+	}
+
 	$result = $statement->execute();
 	$statement->closeCursor();
 

--- a/fof-db.php
+++ b/fof-db.php
@@ -263,21 +263,22 @@ function fof_db_feed_update_metadata($feed_id, $title, $link, $feed_url, $descri
 
 /** Update a feed's WebSub subscription.
  */
-function fof_db_feed_update_websub($feed_id, $websub_hub, $websub_lease) {
+function fof_db_feed_update_websub($feed_id, $hub, $lease, $secret) {
 	global $FOF_FEED_TABLE;
 	global $fof_connection;
 
 	fof_trace();
 
-	$query = "UPDATE $FOF_FEED_TABLE SET feed_websub_hub = :websub_hub, feed_websub_lease = :websub_lease WHERE feed_id = :feed_id";
-	$statement = $fof_connetion->prepare($query);
+	$query = "UPDATE $FOF_FEED_TABLE SET feed_websub_hub = :hub, feed_websub_lease = :lease, feed_websub_secret = :secret WHERE feed_id = :feed_id";
+	$statement = $fof_connection->prepare($query);
 	$statement->bindValue(':feed_id', $feed_id);
-	$statement->bindValue(':websub_hub', $websub_hub);
+	$statement->bindValue(':hub', $hub);
 	if (!empty($websub_lease)) {
-		$statement->bindValue(':websub_lease', $websub_lease);
+		$statement->bindValue(':lease', $lease);
 	} else {
-		$statement->bindValue(':websub_lease', null, PDO::PARAM_NULL);
+		$statement->bindValue(':lease', null, PDO::PARAM_NULL);
 	}
+	$statement->bindValue(':secret', $secret);
 
 	$result = $statement->execute();
 	$statement->closeCursor();

--- a/fof-install.php
+++ b/fof-install.php
@@ -197,6 +197,7 @@ function fof_install_schema() {
 	$tables[FOF_FEED_TABLE][] = "feed_cache_last_attempt_status TEXT";
 	$tables[FOF_FEED_TABLE][] = "feed_websub_hub TEXT";
 	$tables[FOF_FEED_TABLE][] = "feed_websub_lease " . SQL_DRIVER_INT_TYPE . " DEFAULT '0'";
+	$tables[FOF_FEED_TABLE][] = "feed_websub_secret TEXT";
 	if (defined('USE_MYSQL')) {
 		$tables[FOF_FEED_TABLE][] = "PRIMARY KEY ( feed_id )";
 		$tables[FOF_FEED_TABLE][] = "KEY feed_cache_next_attempt ( feed_cache_next_attempt )";
@@ -712,6 +713,10 @@ END";
 
 		fof_install_migrate_column($queries, FOF_FEED_TABLE, 'feed_websub_lease', array(
 			'add' => "ALTER TABLE " . FOF_FEED_TABLE . " ADD feed_websub_lease " . SQL_DRIVER_INT_TYPE . (defined(USE_MYSQL) ? " AFTER feed_websub_hub" : ""),
+		));
+
+		fof_install_migrate_column($queries, FOF_FEED_TABLE, 'feed_websub_secret', array(
+			'add' => "ALTER TABLE " . FOF_FEED_TABLE . " ADD feed_websub_secret TEXT" . (defined(USE_MYSQL) ? " AFTER feed_websub_lease" : ""),
 		));
 
 		if (!defined('USE_SQLITE')) {

--- a/fof-install.php
+++ b/fof-install.php
@@ -195,6 +195,8 @@ function fof_install_schema() {
 	$tables[FOF_FEED_TABLE][] = "feed_cache_next_attempt " . SQL_DRIVER_INT_TYPE . " DEFAULT '0'";
 	$tables[FOF_FEED_TABLE][] = "feed_cache TEXT"; /* FIXME: unused column? */
 	$tables[FOF_FEED_TABLE][] = "feed_cache_last_attempt_status TEXT";
+	$tables[FOF_FEED_TABLE][] = "feed_websub_hub TEXT";
+	$tables[FOF_FEED_TABLE][] = "feed_websub_lease " . SQL_DRIVER_INT_TYPE . " DEFAULT '0'";
 	if (defined('USE_MYSQL')) {
 		$tables[FOF_FEED_TABLE][] = "PRIMARY KEY ( feed_id )";
 		$tables[FOF_FEED_TABLE][] = "KEY feed_cache_next_attempt ( feed_cache_next_attempt )";
@@ -702,6 +704,14 @@ END";
 
 		fof_install_migrate_column($queries, FOF_FEED_TABLE, 'feed_cache_last_attempt_status', array(
 			'add' => "ALTER TABLE " . FOF_FEED_TABLE . " ADD feed_cache_last_attempt_status TEXT" . (defined(USE_MYSQL) ? " AFTER feed_cache_next_attempt" : ""),
+		));
+
+		fof_install_migrate_column($queries, FOF_FEED_TABLE, 'feed_websub_hub', array(
+			'add' => "ALTER TABLE " . FOF_FEED_TABLE . " ADD feed_websub_hub TEXT" . (defined(USE_MYSQL) ? " AFTER feed_cache_last_attempt_status" : ""),
+		));
+
+		fof_install_migrate_column($queries, FOF_FEED_TABLE, 'feed_websub_lease', array(
+			'add' => "ALTER TABLE " . FOF_FEED_TABLE . " ADD feed_websub_lease " . SQL_DRIVER_INT_TYPE . (defined(USE_MYSQL) ? " AFTER feed_websub_hub" : ""),
 		));
 
 		if (!defined('USE_SQLITE')) {

--- a/fof-main.php
+++ b/fof-main.php
@@ -1794,7 +1794,7 @@ function fof_base_url() {
 	if ($_SERVER["SERVER_PORT"] != $defaultPort) {
 		$pageURL .= ':' . $_SERVER["SERVER_PORT"];
 	}
-	$pageURL .= $_SERVER['PHP_SELF'];
+	$pageURL .= $_SERVER['SCRIPT_NAME'];
 	return $pageURL;
 }
 ?>

--- a/fof-main.php
+++ b/fof-main.php
@@ -1251,6 +1251,7 @@ function fof_subscribe_websub($feed_id, $feed_url, $hub, $secret) {
 
 	fof_db_feed_update_websub($feed_id, $hub, $secret);
 
+	fof_log("base URL is " . fof_base_url());
 	$callback = urljoin(fof_base_url(), "websub.php/$feed_id/$secret");
 	fof_log("Callback URL is $callback");
 

--- a/fof-main.php
+++ b/fof-main.php
@@ -846,7 +846,7 @@ function fof_parse($url, $body = null)
 
 	$pie = fof_new_parser();
 	if ($body) {
-		$pie->set_feed_body($body);
+		$pie->set_raw_data($body);
 	} else {
 		$pie->set_feed_url($url);
 	}

--- a/fof-main.php
+++ b/fof-main.php
@@ -1249,9 +1249,9 @@ function fof_subscribe_websub($feed_id, $feed_url, $hub, $secret) {
 		fof_log("Reused existing secret");
 	}
 
-	fof_db_feed_update_websub($feed_id, $hub, 0, $secret);
-	$callback = urljoin(fof_base_url(), "websub.php/$feed_id/$secret");
+	fof_db_feed_update_websub($feed_id, $hub, $secret);
 
+	$callback = urljoin(fof_base_url(), "websub.php/$feed_id/$secret");
 	fof_log("Callback URL is $callback");
 
 	// send the callback subscription to the hub

--- a/fof-main.php
+++ b/fof-main.php
@@ -1793,7 +1793,7 @@ function fof_base_url() {
 	if ($_SERVER["SERVER_PORT"] != $defaultPort) {
 		$pageURL .= ':' . $_SERVER["SERVER_PORT"];
 	}
-	$pageURL .= $_SERVER['REQUEST_URI'];
+	$pageURL .= $_SERVER['PHP_SELF'];
 	return $pageURL;
 }
 ?>

--- a/fof-main.php
+++ b/fof-main.php
@@ -1081,11 +1081,11 @@ function fof_update_feed($id, $body = null) {
 
 	// Update WebSub subscriptions
 	$feed_websub_hub = $rss->get_link(0, 'hub');
-	if ($feed_websub_hub && ($feed_websub_hub != $feed['websub_hub']
-		|| $feed['websub_lease'] < $now)) {
+	if ($feed_websub_hub && ($feed_websub_hub != $feed['feed_websub_hub']
+		|| $feed['feed_websub_lease'] < $now)) {
 		// Either the hub has changed, or the lease is expiring. Update the subscription.
 		fof_log("Updating WebSub subscription for $feed_url ($feed_id)");
-		fof_subscribe_websub($feed_id, $feed_url, $feed_websub_hub, $feed['websub_secret']);
+		fof_subscribe_websub($feed_id, $feed_url, $feed_websub_hub, $feed['feed_websub_secret']);
 	}
 
 	unset($rss);

--- a/library/urljoin.php
+++ b/library/urljoin.php
@@ -5,46 +5,94 @@
 A spiritual port of Python's urlparse.urljoin() function to PHP. Why this isn't in the standard library is anyone's guess.
 
 Author: fluffy, http://beesbuzz.biz/
-Latest version at: https://github.com/plaidfluff/php-urljoin
+Latest version at: https://github.com/fluffy-critter/php-urljoin
 
  */
 
 function urljoin($base, $rel) {
+	if (!$base) {
+		return $rel;
+	}
+
+	if (!$rel) {
+		return $base;
+	}
+
+	$uses_relative = array('', 'ftp', 'http', 'gopher', 'nntp', 'imap',
+		'wais', 'file', 'https', 'shttp', 'mms',
+		'prospero', 'rtsp', 'rtspu', 'sftp',
+		'svn', 'svn+ssh', 'ws', 'wss');
+
 	$pbase = parse_url($base);
 	$prel = parse_url($rel);
 
-	$merged = array_merge($pbase, $prel);
-	if ($prel['path'][0] != '/') {
-		// Relative path
-		$dir = preg_replace('@/[^/]*$@', '', $pbase['path']);
-		$merged['path'] = $dir . '/' . $prel['path'];
+	if ($prel === false || preg_match('/^[a-z0-9\-.]*[^a-z0-9\-.:][a-z0-9\-.]*:/i', $rel)) {
+		/*
+			Either parse_url couldn't parse this, or the original URL
+			fragment had an invalid scheme character before the first :,
+			which can confuse parse_url
+		*/
+		$prel = array('path' => $rel);
 	}
 
-	// Get the path components, and remove the initial empty one
-	$pathParts = explode('/', $merged['path']);
-	array_shift($pathParts);
+	if (array_key_exists('path', $pbase) && $pbase['path'] === '/') {
+		unset($pbase['path']);
+	}
 
-	$path = [];
-	$prevPart = '';
-	foreach ($pathParts as $part) {
-		if ($part == '..' && count($path) > 0) {
-			// Cancel out the parent directory (if there's a parent to cancel)
-			$parent = array_pop($path);
-			// But if it was also a parent directory, leave it in
-			if ($parent == '..') {
-				array_push($path, $parent);
+	if (isset($prel['scheme'])) {
+		if ($prel['scheme'] != $pbase['scheme'] || in_array($prel['scheme'], $uses_relative) == false) {
+			return $rel;
+		}
+	}
+
+	$merged = array_merge($pbase, $prel);
+
+	// Handle relative paths:
+	//   'path/to/file.ext'
+	// './path/to/file.ext'
+	if (array_key_exists('path', $prel) && substr($prel['path'], 0, 1) != '/') {
+
+		// Normalize: './path/to/file.ext' => 'path/to/file.ext'
+		if (substr($prel['path'], 0, 2) === './') {
+			$prel['path'] = substr($prel['path'], 2);
+		}
+
+		if (array_key_exists('path', $pbase)) {
+			$dir = preg_replace('@/[^/]*$@', '', $pbase['path']);
+			$merged['path'] = $dir . '/' . $prel['path'];
+		} else {
+			$merged['path'] = '/' . $prel['path'];
+		}
+
+	}
+
+	if(array_key_exists('path', $merged)) {
+		// Get the path components, and remove the initial empty one
+		$pathParts = explode('/', $merged['path']);
+		array_shift($pathParts);
+
+		$path = [];
+		$prevPart = '';
+		foreach ($pathParts as $part) {
+			if ($part == '..' && count($path) > 0) {
+				// Cancel out the parent directory (if there's a parent to cancel)
+				$parent = array_pop($path);
+				// But if it was also a parent directory, leave it in
+				if ($parent == '..') {
+					array_push($path, $parent);
+					array_push($path, $part);
+				}
+			} else if ($prevPart != '' || ($part != '.' && $part != '')) {
+				// Don't include empty or current-directory components
+				if ($part == '.') {
+					$part = '';
+				}
 				array_push($path, $part);
 			}
-		} else if ($prevPart != '' || ($part != '.' && $part != '')) {
-			// Don't include empty or current-directory components
-			if ($part == '.') {
-				$part = '';
-			}
-			array_push($path, $part);
+			$prevPart = $part;
 		}
-		$prevPart = $part;
+		$merged['path'] = '/' . implode('/', $path);
 	}
-	$merged['path'] = '/' . implode('/', $path);
 
 	$ret = '';
 	if (isset($merged['scheme'])) {

--- a/shared.php
+++ b/shared.php
@@ -57,7 +57,7 @@ $qv = array('user' => $user,
 	'which' => isset($_GET['which']) ? $_GET['which'] : NULL,
 	'feed' => isset($_GET['feed']) ? $_GET['feed'] : NULL,
 );
-$baseurl = 'http' . (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off' ? 's' : '') . '://' . $_SERVER['SERVER_NAME'] . $_SERVER['PHP_SELF'];
+$baseurl = fof_base_url();
 $shared_feed = fof_url($baseurl, array_merge($qv, array('format' => 'atom')));
 $shared_link = fof_url($baseurl, $qv);
 

--- a/websub.php
+++ b/websub.php
@@ -38,7 +38,7 @@ if (!$feed['feed_websub_hub'] || $secret != $feed['feed_websub_secret']) {
     die("Bad push: id=$feed_id secret=$secret");
 }
 
-if (array_key_exists('hub.mode', $_GET) && $_GET['hub.mode'] == 'subscribe') {
+if ($_GET['hub.mode'] == 'subscribe') {
     // We are responding to a subscription verification
     $topic = $_GET['hub.topic'];
     $challenge = $_GET['hub.challenge'];

--- a/websub.php
+++ b/websub.php
@@ -35,9 +35,10 @@ if (!$feed['feed_websub_hub'] || $secret != $feed['feed_websub_secret']) {
     // A bad actor was trying to push an update
     http_response_code(403);
     fof_log("Hub attempted bad push: id=$feed_id secret=$secret");
+    die("Bad push: id=$feed_id secret=$secret");
 }
 
-if ($_GET['hub.mode'] == 'subscribe') {
+if (array_key_exists('hub.mode', $_GET) && $_GET['hub.mode'] == 'subscribe') {
     // We are responding to a subscription verification
     $topic = $_GET['hub.topic'];
     $challenge = $_GET['hub.challenge'];

--- a/websub.php
+++ b/websub.php
@@ -53,7 +53,7 @@ if ($_GET['hub.mode'] == 'subscribe') {
 }
 
 // We're responding to a push response.
-fof_update_feed($feed_id, http_get_request_body());
+fof_update_feed($feed_id, file_get_contents('php://input'));
 ?>
 
 Updated feed <?=$feed_id?>.

--- a/websub.php
+++ b/websub.php
@@ -20,10 +20,10 @@ list($pre, $feed_id, $secret) = explode('/', $_SERVER['PATH_INFO']);
 if (!$feed_id) {
     // No feed ID was specified
     http_response_code(400);
-    die("Malformed request")
+    die("Malformed request");
 }
 
-$feed = fof_get_feed($feed_id);
+$feed = fof_db_get_feed_by_id($feed_id);
 if (!$feed || !$feed['feed_websub_hub']) {
     // The feed doesn't exist, or doesn't have a known hub
     http_response_code(404);
@@ -42,7 +42,7 @@ if ($_GET['hub.mode'] == 'subscribe') {
     $topic = $_GET['hub.topic'];
     $challenge = $_GET['hub.challenge'];
     $lease_time = $_GET['hub.lease_seconds'];
-    fof_log("Got subscription verification request: id=$feed_id topic=$topic lease_time=$lease_time")
+    fof_log("Got subscription verification request: id=$feed_id topic=$topic lease_time=$lease_time");
 
     // Set the lease to renew when they're down to 10% of their lifetime
     fof_db_update_websub($feed_id, $feed['feed_websub_hub'], now() + $lease_time*9/10, $secret);

--- a/websub.php
+++ b/websub.php
@@ -54,6 +54,7 @@ if ($_GET['hub_mode'] == 'subscribe') {
 }
 
 // We're responding to a push response.
+fof_log("Got a WebSub push notification for feed $feed_id");
 fof_update_feed($feed_id, file_get_contents('php://input'));
 ?>
 

--- a/websub.php
+++ b/websub.php
@@ -46,7 +46,7 @@ if (array_key_exists('hub.mode', $_GET) && $_GET['hub.mode'] == 'subscribe') {
     fof_log("Got subscription verification request: id=$feed_id topic=$topic lease_time=$lease_time");
 
     // Set the lease to renew when they're down to 10% of their lifetime
-    fof_db_update_websub($feed_id, $feed['feed_websub_hub'], now() + $lease_time*9/10, $secret);
+    fof_db_update_websub($feed_id, $feed['feed_websub_hub'], $secret, now() + $lease_time*9/10);
 
     // Respond with the challenge and exit
     echo $challenge;

--- a/websub.php
+++ b/websub.php
@@ -38,7 +38,7 @@ if (!$feed['feed_websub_hub'] || $secret != $feed['feed_websub_secret']) {
     die("Bad push: id=$feed_id secret=$secret");
 }
 
-if ($_GET['hub_mode'] == 'subscribe') {
+if (isset($_GET['hub_mode']) && $_GET['hub_mode'] == 'subscribe') {
     // We are responding to a subscription verification
     $topic = $_GET['hub_topic'];
     $challenge = $_GET['hub_challenge'];

--- a/websub.php
+++ b/websub.php
@@ -38,11 +38,11 @@ if (!$feed['feed_websub_hub'] || $secret != $feed['feed_websub_secret']) {
     die("Bad push: id=$feed_id secret=$secret");
 }
 
-if ($_GET['hub.mode'] == 'subscribe') {
+if ($_GET['hub_mode'] == 'subscribe') {
     // We are responding to a subscription verification
-    $topic = $_GET['hub.topic'];
-    $challenge = $_GET['hub.challenge'];
-    $lease_time = $_GET['hub.lease_seconds'];
+    $topic = $_GET['hub_topic'];
+    $challenge = $_GET['hub_challenge'];
+    $lease_time = $_GET['hub_lease_seconds'];
     fof_log("Got subscription verification request: id=$feed_id topic=$topic lease_time=$lease_time");
 
     // Set the lease to renew when they're down to 10% of their lifetime

--- a/websub.php
+++ b/websub.php
@@ -46,7 +46,7 @@ if ($_GET['hub_mode'] == 'subscribe') {
     fof_log("Got subscription verification request: id=$feed_id topic=$topic lease_time=$lease_time");
 
     // Set the lease to renew when they're down to 10% of their lifetime
-    fof_db_update_websub($feed_id, $feed['feed_websub_hub'], $secret, now() + $lease_time*9/10);
+    fof_db_feed_update_websub($feed_id, $feed['feed_websub_hub'], $secret, now() + $lease_time*9/10);
 
     // Respond with the challenge and exit
     echo $challenge;

--- a/websub.php
+++ b/websub.php
@@ -46,7 +46,7 @@ if ($_GET['hub_mode'] == 'subscribe') {
     fof_log("Got subscription verification request: id=$feed_id topic=$topic lease_time=$lease_time");
 
     // Set the lease to renew when they're down to 10% of their lifetime
-    fof_db_feed_update_websub($feed_id, $feed['feed_websub_hub'], $secret, now() + $lease_time*9/10);
+    fof_db_feed_update_websub($feed_id, $feed['feed_websub_hub'], $secret, time() + $lease_time*9/10);
 
     // Respond with the challenge and exit
     echo $challenge;

--- a/websub.php
+++ b/websub.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * This file is part of FEED ON FEEDS - http://feedonfeeds.com/
+ *
+ * websub.php - WebSub endpoint
+ *
+ * Copyright (C) 2018 j. shagam
+ * fluffy@beesbuzz.biz - http://beesbuzz.biz/
+ *
+ * Distributed under the GPL - see LICENSE
+ *
+ */
+
+$fof_no_login = true;
+
+require_once 'fof-main.php';
+
+list($pre, $feed_id, $secret) = explode('/', $_SERVER['PATH_INFO']);
+
+if (!$feed_id) {
+    // No feed ID was specified
+    http_response_code(400);
+    die("Malformed request")
+}
+
+$feed = fof_get_feed($feed_id);
+if (!$feed || !$feed['feed_websub_hub']) {
+    // The feed doesn't exist, or doesn't have a known hub
+    http_response_code(404);
+    fof_log("Got push to unknown feed: id=$feed_id", 'warning');
+    die("No such feed $feed_id");
+}
+
+if (!$feed['feed_websub_hub'] || $secret != $feed['feed_websub_secret']) {
+    // A bad actor was trying to push an update
+    http_response_code(403);
+    fof_log("Hub attempted bad push: id=$feed_id secret=$secret");
+}
+
+if ($_GET['hub.mode'] == 'subscribe') {
+    // We are responding to a subscription verification
+    $topic = $_GET['hub.topic'];
+    $challenge = $_GET['hub.challenge'];
+    $lease_time = $_GET['hub.lease_seconds'];
+    fof_log("Got subscription verification request: id=$feed_id topic=$topic lease_time=$lease_time")
+
+    // Set the lease to renew when they're down to 10% of their lifetime
+    fof_db_update_websub($feed_id, $feed['feed_websub_hub'], now() + $lease_time*9/10, $secret);
+
+    // Respond with the challenge and exit
+    echo $challenge;
+    exit();
+}
+
+// We're responding to a push response.
+fof_update_feed($feed_id, http_get_request_body());
+?>
+
+Updated feed <?=$feed_id?>.


### PR DESCRIPTION
This update adds support for [WebSub](https://en.wikipedia.org/wiki/WebSub) (formerly PubSubHubBub) to Feed-On-Feeds. If FoF detects a WebSub hub in a feed, it will register its callback handler with it, and use that to get immediate updates when a post goes live. This does *not* prevent it from polling a feed for updates down the road, though; it simply uses the notification as a fast-track for receiving an update.

If the originating feed's hub changes then it will be updated at the next poll. The polling interval will be based on the last push time, so frequently-updating feeds will essentially operate as push-only.

At poll time it will also update the WebSub subscription if it's getting ready for renewal. Currently it does this if the subscription lease time is below 10% of its original duration.

If this is running on localhost or behind a firewall it does generate a small amount of excess traffic to the hub but the subscription never activates.

Also, it can only form the callback URL if the update is happening from a web request. The typical use case is a cron job that looks like:

```
* * * * * curl http://example.com/fof/update-quiet.php
```

but if it's instead being updated with e.g.

```
* * * * * php /path/to/update-quiet.php
```

then WebSub subscriptions won't work. (But this is not a supported configuration so this shouldn't be an issue.)