### PR TITLE
Various bugfixes in entity decoding and feed discovery

### DIFF
--- a/fof.css
+++ b/fof.css
@@ -574,6 +574,11 @@ td.feed-prefs-header {
   height: auto;
 }
 
+.video-source {
+  display: inline-block;
+  margin: 10px 0;
+}
+
 .item pre {
   white-space: pre-wrap;
 }

--- a/fof.css
+++ b/fof.css
@@ -5,6 +5,14 @@ body {
   padding: 0;
 }
 
+blockquote {
+  margin: 10px;
+}
+
+figure {
+  margin: 0;
+}
+
 .hide {
   display: none !important;
 }
@@ -558,6 +566,12 @@ h2 {
 
 td.feed-prefs-header {
   vertical-align: top;
+}
+
+.item .body img,
+.item .body video {
+  max-width: 100%;
+  height: auto;
 }
 
 .item pre {

--- a/fof.js
+++ b/fof.js
@@ -843,6 +843,27 @@ function embed_vimeo ( element ) {
 	element.parentNode.replaceChild(iframe, element);
 }
 
+window.onload = function() {
+	document.querySelectorAll('.item .body video').forEach(video => {
+		let source = '';
+
+		if (video.src) {
+			source = video.src;
+		} else {
+			source = video.querySelector('source').src;
+		}
+
+		// tumblr feature: try full video size
+		source = source.replace(/\/[0-9]+$/, '');
+
+		let html = video.outerHTML;
+
+		html += '<br/>🎞 <a href="'+source+'" class="video-source">Video source</a>';
+
+		video.outerHTML = '<div class="video-wrap">'+html+'</div>';
+	});
+};
+
 
 /**
  * HELPER FUNCTIONS


### PR DESCRIPTION
1. `fof_render()` was unescaping entities that did not need unescaping (fixes #36)
2. Some feeds like questionablecontent.net have a `<link rel="self">` that does not match the actual feed URL; this change will only use the `rel="self"` URL if it points to a valid feed (both on initial subscribe and on feed update).