### PR TITLE
Don't update feed metadata if it came from a WebSub push

### DIFF
--- a/fof-main.php
+++ b/fof-main.php
@@ -994,11 +994,13 @@ function fof_update_feed($id, $body = null) {
 	$feed_description = $rss->get_description();
 	$feed_url = urljoin($feed['feed_url'], $rss->get_link(0, 'self'));
 
-	/* set the feed's current information */
-	fof_db_feed_update_metadata($id, $feed_title, $feed_link,
-		$feed_url,
-		$feed_description,
-		$feed_image, $feed_image_cache_date);
+	if (!$body) {
+		/* set the feed's current information */
+		fof_db_feed_update_metadata($id, $feed_title, $feed_link,
+			$feed_url,
+			$feed_description,
+			$feed_image, $feed_image_cache_date);
+	}
 
 	$feed_id = $feed['feed_id'];
 	$n = 0;


### PR DESCRIPTION
Apparently, SuperFeedr doesn't forward feed metadata along, so WebSub updates cause FoF to lose the feed title among other things. So we only want to update metadata on a backfill pull.