### PR TITLE
Fix websub

### DIFF
--- a/fof-db.php
+++ b/fof-db.php
@@ -1253,13 +1253,13 @@ function fof_db_get_subscription_to_tags() {
 	$query = "SELECT * FROM $FOF_SUBSCRIPTION_TABLE";
 	$statement = $fof_connection->query($query);
 	while (($row = fof_db_get_row($statement)) !== false) {
-		$feed_id = $row['feed_id'];
-		$user_id = $row['user_id'];
+		$feed_id = (int)$row['feed_id'];
+		$user_id = (int)$row['user_id'];
 		$prefs = unserialize($row['subscription_prefs']);
 		if (!isset($r[$feed_id])) {
-			$r[(int)$feed_id] = array();
+			$r[$feed_id] = array();
 		}
-		$r[(int)$feed_id][(int)$user_id] = $prefs['tags'];
+		$r[$feed_id][$user_id] = $prefs['tags'];
 	}
 
 	return $r;

--- a/img.php
+++ b/img.php
@@ -24,13 +24,10 @@ if (!$item) {
 // fix relative URLs with $item['item_link']
 $url = urljoin($item['item_link'], $url);
 
-// This is a really annoying way to get the final header chunk. There's got to be a better way...
-$final = false;
 function dump_headers($ch, $header) {
-	global $final;
-	if (preg_match('@HTTP/[^ ]* [12456789]@', $header)) {
-		$final = true;
-	} else if ($final && strpos($header, ':')) {
+	$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+	$url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+	if (($http_code < 300 || $http_code >= 400) && strpos($header, ':')) {
 		fof_log("image $url header: $header");
 		header(rtrim($header));
 	}

--- a/websub.php
+++ b/websub.php
@@ -38,11 +38,11 @@ if (!$feed['feed_websub_hub'] || $secret != $feed['feed_websub_secret']) {
     die("Bad push: id=$feed_id secret=$secret");
 }
 
-if (isset($_GET['hub_mode']) && $_GET['hub_mode'] == 'subscribe') {
+if (isset($_GET['hub.mode']) && $_GET['hub.mode'] == 'subscribe') {
     // We are responding to a subscription verification
-    $topic = $_GET['hub_topic'];
-    $challenge = $_GET['hub_challenge'];
-    $lease_time = $_GET['hub_lease_seconds'];
+    $topic = $_GET['hub.topic'];
+    $challenge = $_GET['hub.challenge'];
+    $lease_time = $_GET['hub.lease_seconds'];
     fof_log("Got subscription verification request: id=$feed_id topic=$topic lease_time=$lease_time");
 
     // Set the lease to renew when they're down to 10% of their lifetime


### PR DESCRIPTION
PHP keeps on changing its mind about whether or not to rename `.` in GET/POST variables to `_`. I still can't get a straight answer about this. But it seems that at least in PHP 7.4, it's not doing that rewrite anymore. I think. I'm not sure anymore.