### PR TITLE
Require whitespace after srcset separator to fix certain feeds

### DIFF
--- a/plugins/images_by_proxy.php
+++ b/plugins/images_by_proxy.php
@@ -18,7 +18,7 @@ function fof_images_by_proxy($dom, $item) {
 		foreach (['srcset', 'data-fof-ondemand-srcset'] as $attr) {
 			if ($img->hasAttribute($attr)) {
 				$srcset = $img->getAttribute($attr);
-				$specs = preg_split('/,\s*/', $srcset);
+				$specs = preg_split('/,\s+/', $srcset);
 
 				$outspec = [];
 				foreach ($specs as $spec) {


### PR DESCRIPTION
The `images_on_demand` plugin was subtly broken on a couple of feeds where the `srcset` attribute might sometimes contain commas in the URLs; for example, hackaday.com uses commas as part of its rendition arguments. This is highly-discouraged and they probably should be %-encoding them, but the resulting attribute was supported on every web browser I tried.

The [W3C specification for `srcset`](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes) maintains that the post-separator whitespace is optional with a rather confusing caveat, but in any case I have no interest in making a fully-fledged rule parser for this simple hack, and it's easy enough to just treat the separator as `,\s+` instead of `,\s*`.