### PR TITLE
Fix SVG sizes

### DIFF
--- a/fof.css
+++ b/fof.css
@@ -28,7 +28,8 @@ h1 span.author {
   font-size: x-small;
 }
 
-a img {
+a img,
+a svg {
   border: 0;
 }
 
@@ -571,7 +572,8 @@ td.feed-prefs-header {
 }
 
 .item .body img,
-.item .body video {
+.item .body video,
+.item .body svg {
   max-width: 100%;
   height: auto;
 }

--- a/plugins/fix_svg_dimensions.ini
+++ b/plugins/fix_svg_dimensions.ini
@@ -1,0 +1,2 @@
+type="domitemfilter"
+description="Add width and height attributes to inline SVGs"

--- a/plugins/fix_svg_dimensions.php
+++ b/plugins/fix_svg_dimensions.php
@@ -1,0 +1,24 @@
+<?php
+
+/* For an SVG item with a viewbox but no width/height attributes, generate those attributes, to stop social icons and emojis from filling up the entire page */
+
+fof_add_domitem_filter('fof_fix_svg_dimensions');
+
+function fof_fix_svg_dimensions($dom, $item) {
+	foreach ($dom->getElementsByTagName('svg') as $svg) {
+        if ($svg->hasAttribute('viewbox')) {
+		$viewBox = preg_split('/\s+/', $svg->getAttribute('viewbox'), -1, PREG_SPLIT_NO_EMPTY);
+            if (!$svg->hasAttribute('width')) {
+                $svg->setAttribute('width', (int)$viewBox[2] - (int)$viewBox[0]);
+            }
+            if (!$svg->hasAttribute('height')) {
+                $svg->setAttribute('height', (int)$viewBox[3] - (int)$viewBox[1]);
+            }
+        }
+    }
+
+    return $dom;
+}
+
+?>
+


### PR DESCRIPTION
A lot of RSS feeds use inline SVGs for emojis, sharing icons, etc., and don't specify a width/height attribute on them, expecting the browser's viewBox to be sufficient. This makes those images end up expanding to fill the entire freaking window, which is, y'know, not great.

This plugin uses the viewBox to compute width and height for inline SVGs that don't specify their size.